### PR TITLE
Use htmlPreProc cluster for improved syntax highlighting

### DIFF
--- a/syntax/mako.vim
+++ b/syntax/mako.vim
@@ -2,8 +2,8 @@
 " Language:     Mako
 " Maintainer:   Armin Ronacher <armin.ronacher@active-4.com>
 " URL:          http://lucumr.pocoo.org/
-" Last Change:  2008 September 12
-" Version:      0.6.1
+" Last Change:  2013-05-01
+" Version:      0.6.1+
 "
 " Thanks to Brine Rue <brian@lolapps.com> who noticed a bug in the
 " delimiter handling.


### PR DESCRIPTION
Using the latest vim and mako
I found that a lot of my mako syntax wasn't getting highlighted depending on the surrounding html tags.

In reading the help file for `html.vim` I found that it has built-in support for a pre-processor
and utilizing it greatly improves the highlighting.

I also added support for namespaced defs which newer versions of mako support.
