### PR TITLE
indent using two spaces

### DIFF
--- a/indent/mako.vim
+++ b/indent/mako.vim
@@ -42,8 +42,6 @@
 "       0.1 - 06 June 2009
 "       - Initial public release of mako indent file
 
-let sw=2    " default shiftwidth of 2 spaces
-
 if exists("b:did_indent")
     finish
 endif
@@ -53,6 +51,9 @@ setlocal nosmartindent
 setlocal noautoindent
 setlocal nocindent
 setlocal nolisp
+setlocal expandtab
+setlocal softtabstop=2
+setlocal shiftwidth=2
 
 setlocal indentexpr=GetMakoIndent()
 setlocal indentkeys+=*<Return>,<>>,<bs>,end,:


### PR DESCRIPTION
I discovered that if I opened up a mako file and try to indent using `=`, vim will re-indent the whole file using 4 spaces, so I added a few extra options to change this behavior and use 2 spaces indent.