### PR TITLE
add match_words from html to mako for tag matching

### DIFF
--- a/ftplugin/mako.vim
+++ b/ftplugin/mako.vim
@@ -1,11 +1,19 @@
 " Vim filetype plugin file
 " Language:     Mako
 " Maintainer:   Randy Stauner <randy@magnificent-tears.com>
-" Last Change:  2014-02-07
-" Version:      0.1
+" Last Change:  2019-09-06
+" Version:      0.2
 
-if exists("b:did_ftplugin") | finish | endif
+if exists('b:did_ftplugin') | finish | endif
 let b:did_ftplugin = 1
 
 setlocal comments=:##
 setlocal commentstring=##%s
+
+if exists('loaded_matchit')
+  let b:match_ignorecase = 1
+  let b:match_words = '<:>,' .
+  \ '<\@<=[ou]l\>[^>]*\%(>\|$\):<\@<=li\>:<\@<=/[ou]l>,' .
+  \ '<\@<=dl\>[^>]*\%(>\|$\):<\@<=d[td]\>:<\@<=/dl>,' .
+  \ '<\@<=\([^/][^ \t>]*\)[^>]*\%(>\|$\):<\@<=/\1>'
+endif

--- a/ftplugin/mako.vim
+++ b/ftplugin/mako.vim
@@ -4,16 +4,16 @@
 " Last Change:  2019-09-06
 " Version:      0.2
 
-if exists('b:did_ftplugin') | finish | endif
+if exists("b:did_ftplugin") | finish | endif
 let b:did_ftplugin = 1
 
 setlocal comments=:##
 setlocal commentstring=##%s
 
-if exists('loaded_matchit')
+if exists("loaded_matchit")
   let b:match_ignorecase = 1
-  let b:match_words = '<:>,' .
-  \ '<\@<=[ou]l\>[^>]*\%(>\|$\):<\@<=li\>:<\@<=/[ou]l>,' .
-  \ '<\@<=dl\>[^>]*\%(>\|$\):<\@<=d[td]\>:<\@<=/dl>,' .
-  \ '<\@<=\([^/][^ \t>]*\)[^>]*\%(>\|$\):<\@<=/\1>'
+  let b:match_words = "<:>," .
+  \ "<\@<=[ou]l\>[^>]*\%(>\|$\):<\@<=li\>:<\@<=/[ou]l>," .
+  \ "<\@<=dl\>[^>]*\%(>\|$\):<\@<=d[td]\>:<\@<=/dl>," .
+  \ "<\@<=\([^/][^ \t>]*\)[^>]*\%(>\|$\):<\@<=/\1>"
 endif


### PR DESCRIPTION
matchit doesn't work for mako because `b:match_words` is not defined. I've added the same value here as HTML. If it needs to be different for some reason, let me know, but this seems to work pretty well so far.

I bumped the Last Change date and Version to reflect the change.