### PR TITLE
add g:mako_extension option

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Useful configuration variables:
   detection.
 * `g:mako_default_outer_lang`: if ftdetect cannot detect the "outer" filetype of
   the file, this sets the default filetype used. If not set, defaults to "html".
+* `g:mako_extension`: set to the default string (with leading dot).  Default is ".mako"
 
 About mako: http://www.makotemplates.org/
 

--- a/ftdetect/mako.vim
+++ b/ftdetect/mako.vim
@@ -1,11 +1,14 @@
 if !exists("g:mako_detect_lang_from_ext")
   let g:mako_detect_lang_from_ext = 1
 endif
+if !exists("g:mako_extension")
+  let g:mako_extension = .mako
+endif
 if g:mako_detect_lang_from_ext
-  au BufNewFile *.*.mako   execute "do BufNewFile filetypedetect " . expand("<afile>:r") | let b:mako_outer_lang = &filetype
+  exe 'au BufNewFile *.*' . g:mako_extension . ' execute "do BufNewFile filetypedetect " . expand("<afile>:r") | let b:mako_outer_lang = &filetype'
   " it's important to get this before any of the normal BufRead autocmds execute
   " for this file, otherwise a mako tag at the start of the file can cause the
   " filetype to be set to mason
-  au BufReadPre *.*.mako   execute "do BufRead filetypedetect " . expand("<afile>:r") | let b:mako_outer_lang = &filetype
+  exe 'au BufReadPre *.*' . g:mako_extension . ' execute "do BufRead filetypedetect " . expand("<afile>:r") | let b:mako_outer_lang = &filetype'
 endif
-au BufRead,BufNewFile *.mako     set filetype=mako
+exe 'au BufRead,BufNewFile *' . g:mako_extension . ' set filetype=mako'


### PR DESCRIPTION
Added an option to change the default `.mako` extension.   https://github.com/lowRISC/opentitan uses `.tpl` for example.